### PR TITLE
解决CustomizedPropertyEditorRegistrar不生效的问题

### DIFF
--- a/thinking-in-spring/conversion/src/main/resources/META-INF/property-editors-context.xml
+++ b/thinking-in-spring/conversion/src/main/resources/META-INF/property-editors-context.xml
@@ -11,9 +11,15 @@
         http://www.springframework.org/schema/util
         https://www.springframework.org/schema/util/spring-util.xsd">
 
-    <!-- 3. 将其声明为 Spring Bean -->
-    <bean class="org.geekbang.thinking.in.spring.conversion.CustomizedPropertyEditorRegistrar"/>
-
+    <bean id="customEditorConfigurer" class="org.springframework.beans.factory.config.CustomEditorConfigurer">
+        <property name="propertyEditorRegistrars">
+            <list>
+                <!-- 3. 将其声明为 Spring Bean 并注入到customEditorConfigurer-->
+                <bean class="org.geekbang.thinking.in.spring.conversion.CustomizedPropertyEditorRegistrar"/>
+            </list>
+        </property>
+    </bean>
+        
     <!-- 声明 ConversionServiceFactoryBean 并且 name 必须为 "conversionService" -->
     <bean id="conversionService" class="org.springframework.context.support.ConversionServiceFactoryBean">
         <property name="converters">


### PR DESCRIPTION
仅将CustomizedPropertyEditorRegistrar声明为Bean，是无法注册自定义的PropertyEditor，需要借助`CustomEditorConfigurer`后置处理器才能生效.