### PR TITLE
fix(DatabaseUserRepository.java):修复2个bug

### DIFF
--- a/projects/stage-0/user-platform/user-web/src/main/java/org/geektimes/projects/user/repository/DatabaseUserRepository.java
+++ b/projects/stage-0/user-platform/user-web/src/main/java/org/geektimes/projects/user/repository/DatabaseUserRepository.java
@@ -94,6 +94,7 @@ public class DatabaseUserRepository implements UserRepository {
                     // 以 id 为例，  user.setId(resultSet.getLong("id"));
                     setterMethodFromUser.invoke(user, resultValue);
                 }
+                users.add(user);
             }
             return users;
         }, e -> {
@@ -124,7 +125,7 @@ public class DatabaseUserRepository implements UserRepository {
 
                 // Boolean -> boolean
                 String methodName = preparedStatementMethodMappings.get(argType);
-                Method method = PreparedStatement.class.getMethod(methodName, wrapperType);
+                Method method = PreparedStatement.class.getMethod(methodName, int.class, wrapperType);
                 method.invoke(preparedStatement, i + 1, args);
             }
             ResultSet resultSet = preparedStatement.executeQuery();


### PR DESCRIPTION
1. getAll方法中遍历结果集时未将数据add到集合，导致返回值始终为empty list
2. 反射调用PreparedStatement#setXXX方法时缺少参数